### PR TITLE
Update run_CLIPreg.R

### DIFF
--- a/R/run_CLIPreg.R
+++ b/R/run_CLIPreg.R
@@ -24,7 +24,7 @@ run_CLIPreg=function(input_data=Example, is.example=T)
   Targets=combine_targets(RBP_list1=RBP_ENCODE,RBP_list2=RBP_POSTAR,background=gene_groups$geneID)
   res=CLIPreg::combine(res1=res_Encode,res2=res_Postar,FDR=0.1)
   rbp_lfc=rbp_change(res=res,ribo_lfc=ribo_lfc)
-  res=cure_res(res=res,rbp_lfc=rbp_lfc)
+  res=cure_res(res=res,regulators=rbp_lfc)
 
   L=list(gene_groups=gene_groups,
          tpm_ribo=tpm_ribo,


### PR DESCRIPTION
Dear contributors,

First of all, thank you for developing the nice tool. While testing this package with the example data, I encountered with below error:
> results=run_CLIPreg(Example, is.example=T)
Error in cure_res(res = res, rbp_lfc = rbp_lfc) : 
  unused argument (rbp_lfc = rbp_lfc)

After careful observation of the code, I think the argument (rbp_lfc = rbp_lfc) should be changed to (regulators=rbp_lfc).  Could you please update it, if I am correct.

Thanks and regards,
Suhail